### PR TITLE
Add a setting to Hide 'Known Service Problems'

### DIFF
--- a/htdocs/do_settings.php
+++ b/htdocs/do_settings.php
@@ -28,6 +28,12 @@ if (isset($_POST['sort_descending'])) {
     setcookie('sort_descending', '0', time()+60*60*24*365);
 }
 
+if (isset($_POST['hide_ksps'])) {
+    setcookie('hide_ksps', '1', time()+60*60*24*365);
+} else {
+    setcookie('hide_ksps', '0', time()+60*60*24*365);
+}
+
 $submitted_hosts = $_POST;
 $unwanted_hosts = array_diff($hosts, array_keys($submitted_hosts));
 

--- a/htdocs/nagdash.php
+++ b/htdocs/nagdash.php
@@ -60,6 +60,11 @@ if (isset($_COOKIE['sort_descending'])) {
     $filter_sort_descending = (int) $_COOKIE['sort_descending'];
 }
 
+// If 1, the user wants to HIDE "Known Service Problems"; 0 if not.
+if (isset($_COOKIE['hide_ksps'])) {
+    $filter_hide_ksps = (int) $_COOKIE['hide_ksps'];
+}
+
 // Collect the API data from each Nagios host.
 
 if (isset($mock_state_file)) {
@@ -168,32 +173,35 @@ if ((isset($filter_sort_by_time) && $filter_sort_by_time == 1) || $sort_by_time)
     usort($known_services,'NagdashHelpers::cmp_last_state_change');
 }
 
-if (count($known_services) > 0) { ?>
-    <h3 align="center">Known Service Problems</h3>
-    <table class="widetable" id="known_services">
-    <tr style="color:#33b5e5;"><th width="25%">Hostname</th><th width="20%">Service</th><th width="15%">Comment</th><th width="18%">State</th><th width="10%">Duration</th><th width="5%">Attempt</th>
-<?php
+if (isset($filter_hide_ksps) && $filter_hide_ksps == 1) {
+    echo "<!--Known Service Problems hidden by user preference -->";
+} else {
+    if (count($known_services) > 0) {
+        echo '<h3 align="center">Known Service Problems</h3>';
+        echo '<table class="widetable" id="known_services">';
+        echo '<tr style="color:#33b5e5;"><th width="25%">Hostname</th><th width="20%">Service</th><th width="15%">Comment</th><th width="18%">State</th><th width="10%">Duration</th><th width="5%">Attempt</th>';
 
-    foreach($known_services as $service) {
-        if ($service['is_ack']) $status_text = "ack";
-        if ($service['is_downtime']) $status_text = "downtime {$service['downtime_remaining']}";
-        if (!$service['is_enabled']) $status_text = "disabled";
-        echo "<tr class='known_service'>";
-        $tag = NagdashHelpers::print_tag($service['tag'], count($nagios_hosts));
-        $service_comment = '';
-		if(!empty($service['comments'])) {
-			foreach($service['comments'] as $comment) {
-$service_comment .= " ".$comment['comment_data'];
-			}
-		}
-		
-        echo "<td>{$service['hostname']} " . $tag . "</td>";
-        echo "<td>{$service['service_name']}</td>";
-        echo "<td>{$service_comment}</td>";
-        echo "<td class='{$nagios_service_status_colour[$service['service_state']]}'>{$nagios_service_status[$service['service_state']]} ({$status_text})</td>";
-        echo "<td>{$service['duration']}</td>";
-        echo "<td>{$service['current_attempt']}/{$service['max_attempts']}</td>";
-        echo "</tr>";
+        foreach($known_services as $service) {
+            if ($service['is_ack']) $status_text = "ack";
+            if ($service['is_downtime']) $status_text = "downtime {$service['downtime_remaining']}";
+            if (!$service['is_enabled']) $status_text = "disabled";
+            echo "<tr class='known_service'>";
+            $tag = NagdashHelpers::print_tag($service['tag'], count($nagios_hosts));
+            $service_comment = '';
+    		if(!empty($service['comments'])) {
+    			foreach($service['comments'] as $comment) {
+    $service_comment .= " ".$comment['comment_data'];
+    			}
+    		}
+    		
+            echo "<td>{$service['hostname']} " . $tag . "</td>";
+            echo "<td>{$service['service_name']}</td>";
+            echo "<td>{$service_comment}</td>";
+            echo "<td class='{$nagios_service_status_colour[$service['service_state']]}'>{$nagios_service_status[$service['service_state']]} ({$status_text})</td>";
+            echo "<td>{$service['duration']}</td>";
+            echo "<td>{$service['current_attempt']}/{$service['max_attempts']}</td>";
+            echo "</tr>";
+        }
     }
 ?>
 

--- a/htdocs/settings_dialog.php
+++ b/htdocs/settings_dialog.php
@@ -28,6 +28,7 @@
 <input type="input" name="hostfilter" id="hostfilter" value="<?php echo $_COOKIE['nagdash_hostfilter']; ?>">
 <br>ie. ^((?!DESKTOP|PLOTTER|PROJECTOR|PRINTER).)*$ <input type="button" class="btn" onClick="updateRegex(this.value)" value="Test Example"></br>
 </fieldset>
+<fieldset>
 <legend style="color:#ffffff;">Last state change</legend>
 <div class="settings_group">
 <span class="settings_element">
@@ -44,6 +45,9 @@ foreach ($select_last_state_change_options as $time_in_seconds => $time_in_engli
 </select>
 </span>
 <span class="settings_element"> ago</span>
+</div>
+</fieldset>
+<fieldset>
 <legend style="color:#ffffff;">Sort options</legend>
 <?php
 // If the config option 'sort_by_time' is true, check if the user is overriding it.
@@ -76,7 +80,22 @@ Descending?
 <?php echo '<input type="checkbox" name="sort_descending"' . $checked_sort_descending . '>'; ?>
 </label>
 </span>
-</div>
+</fieldset>
+<fieldset>
+<legend>Alert Sections</legend>
+<?php
+$checked_hide_ksps = "";
+if (isset($_COOKIE['hide_ksps']) && $_COOKIE['hide_ksps'] == '1') {
+        $checked_hide_ksps = "checked";
+}
+?>
+<span class="settings_element">
+Hide "Known Service Problems"
+<label class="checkbox inline tag_label">
+<?php echo '<input type="checkbox" name="hide_ksps"' . $checked_hide_ksps . '>'; ?>
+</label>
+</span>
+</fieldset>
 </form>
 </div>
 <div class="modal-footer" style="background-color:#2d2d2d;">


### PR DESCRIPTION
This change adds an option in Settings to hide 'Known Service Problems'

This is useful to present a NOC view of solely 'unacknowledged' problems.