### PR TITLE
Link each DOWN service to its Nagios page

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -7,7 +7,7 @@ $api_type = "nagios-api";
 
 // Your Nagios hosts
 $nagios_hosts = array(
-    array("hostname" => "nagios01.dc1.company.com", "port" => "6315", "protocol" => "http", "tag" => "DC1", "tagcolour" => "#336699"), 
+    array("hostname" => "nagios01.dc1.company.com", "port" => "6315", "protocol" => "http", "tag" => "DC1", "tagcolour" => "#336699", "weburl" => "https://nagios.company.tld/nagios"), 
     array("hostname" => "nagios01.dc2.company.com", "port" => "6315", "protocol" => "http", "tag" => "DC2", "tagcolour" => "#696969"), 
     array("hostname" => "nagios01.dc3.company.com", "port" => "6315", "protocol" => "http", "tag" => "DC3", "tagcolour" => "#4169E1"), 
 // and so on...    

--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -4,7 +4,8 @@ h3                  { margin-top: 3px; margin-bottom: 3px; font-size: 1.5em }
 table,td            { border: none; padding: 2px; border-spacing: 2px; }
 table               { background-color: #F0F0F0; border-collapse: separate; }
 th                  { border: 1px #353535 solid; background-color: #404040 }
-a,a:hover           { color: ffffff; }
+a,a:hover           { color: white; }
+.status_yellow a,a:hover { color: black;}
 .widetable          { width: 100%; clear: both }
 .bold               { font-weight: bold; }
 .status_green       { background-color: #269926; color: white; padding: 3px }

--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -4,6 +4,7 @@ h3                  { margin-top: 3px; margin-bottom: 3px; font-size: 1.5em }
 table,td            { border: none; padding: 2px; border-spacing: 2px; }
 table               { background-color: #F0F0F0; border-collapse: separate; }
 th                  { border: 1px #353535 solid; background-color: #404040 }
+a,a:hover           { color: ffffff; }
 .widetable          { width: 100%; clear: both }
 .bold               { font-weight: bold; }
 .status_green       { background-color: #269926; color: white; padding: 3px }

--- a/htdocs/nagdash.php
+++ b/htdocs/nagdash.php
@@ -151,7 +151,7 @@ if (count($known_hosts) > 0) {
                                                 "host" => $service['hostname'],
                                                 "service" => $service['service_name']]);
         echo "</span></td>";
-        echo "<td class='bold {$nagios_service_status_colour[$service['service_state']]} {$soft_style}'>{$blink_tag}{$service['service_name']}<span class='detail'>{$service['detail']}</span></td>";
+        echo "<td class='bold {$nagios_service_status_colour[$service['service_state']]} {$soft_style}'><a href='{$service['weburl']}' target=\"_blank\">{$blink_tag}{$service['service_name']}</a><span class='detail'>{$service['detail']}</span></td>";
         echo "<td>{$service['duration']}</td>";
         echo "<td>{$service['current_attempt']}/{$service['max_attempts']}</td>";
         echo "</tr>";
@@ -188,7 +188,7 @@ $service_comment .= " ".$comment['comment_data'];
 		}
 		
         echo "<td>{$service['hostname']} " . $tag . "</td>";
-        echo "<td>{$service['service_name']}</td>";
+        echo "<td><a href='{$service['weburl']}' target=\"_blank\">{$service['service_name']}</a></td>";
         echo "<td>{$service_comment}</td>";
         echo "<td class='{$nagios_service_status_colour[$service['service_state']]}'>{$nagios_service_status[$service['service_state']]} ({$status_text})</td>";
         echo "<td>{$service['duration']}</td>";

--- a/phplib/utils.php
+++ b/phplib/utils.php
@@ -180,8 +180,10 @@ class NagdashHelpers {
                 if (is_string($host_state)) {
                     $errors[] = "Could not connect to API on host {$host['hostname']}, port {$host['port']}: {$host_state}";
                 } else {
+                    # copy 'tag' and 'weburl' from the config to the state
                     foreach ($host_state as $this_host => $null) {
                         $host_state[$this_host]['tag'] = $host['tag'];
+                        $host_state[$this_host]['weburl'] = isset($host['weburl']) ? $host['weburl'] : null;
                     }
                     $state += (array) $host_state;
                 }
@@ -281,6 +283,7 @@ class NagdashHelpers {
                         if ($service_detail['last_state_change'] >= $state_change_backstop) {
                             array_push($$array_name, array(
                                 "hostname" => $hostname,
+                                "weburl"   => "{$host_detail['weburl']}/cgi-bin/extinfo.cgi?type=2&host={$hostname}&service={$service_name}",
                                 "service_name" => $service_name,
                                 "service_state" => $service_detail[$api_cols['state']],
                                 "duration" => timeago($service_detail['last_state_change']),


### PR DESCRIPTION
For each service which is DOWN, add a href link back to the associated Nagios service info page.

This patch includes a worked example for config.php.example